### PR TITLE
Use positional access for the reference row in build_tables

### DIFF
--- a/bin/vsnp3_fasta_to_snps_table.py
+++ b/bin/vsnp3_fasta_to_snps_table.py
@@ -287,7 +287,7 @@ class Tables:
             column = tree_order[column_header]
             # for each element in the column
             for element in column:
-                if element != column[0] and element != '-':
+                if element != column.iloc[0] and element != '-':
                     count = count + 1
             snp_per_column.append(count)
         row1 = pd.Series(snp_per_column, tree_order.columns, name="snp_per_column")
@@ -301,7 +301,7 @@ class Tables:
             # for each element in the column
             # skip the first element
             for element in column[1:]:
-                if element == column[0] or element == '-':
+                if element == column.iloc[0] or element == '-':
                     count = count + 1
                 else:
                     break
@@ -332,7 +332,7 @@ class Tables:
             column = tree_order2[column_header]
             index_list_of_ref_differences=[]
             for ind, list_item in enumerate(column[1:].to_list()):
-                if list_item != column[0] and list_item != '-':
+                if list_item != column.iloc[0] and list_item != '-':
                     index_list_of_ref_differences.append(ind)
             if index_list_of_ref_differences:  # Check if list is not empty
                 c = itertools.count()


### PR DESCRIPTION
Fixes #22.

`build_tables` in `bin/vsnp3_fasta_to_snps_table.py` reads the first (root/reference) row of each column with `column[0]` at three sites (lines 290, 304, 335). The column is a `pandas.Series` indexed by sample-name strings, so `column[0]` is a *label* lookup for the label `0`, not positional access. On pandas 2.x that still worked but emitted a deprecation warning; on pandas 3.x it fails hard with `KeyError: 0`, which crashes cascade-table construction during Step 2 (traceback in the issue).

The fix is `column.iloc[0]`, which is the positional access the code intends - the comment on line 290 even notes that `column[0]` is the top row / root / reference. The value returned is unchanged (the first/top row), so behavior is the same on older pandas and no longer crashes on newer pandas.

The repo has no test harness for this module, so I verified the semantics directly: for a string-indexed Series, `s.iloc[0]` returns the first element while `s[0]` raises `KeyError` on pandas 3.x (and warns on 2.x). `python -m py_compile` on the changed file passes.